### PR TITLE
Remove unused request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "babel": "inherit"
   },
   "dependencies": {
-    "node-fetch": "^1.6.3",
-    "request": "^2.79.0"
+    "node-fetch": "^1.6.3"
   }
 }


### PR DESCRIPTION
This module lists both `node-fetch` and `request` as dependencies, but the later is never used.

This PR removes the module from package.json.